### PR TITLE
Allow hyphens in BUS_ADDRESS_REGEX to match canonical SNI bus names

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -243,7 +243,7 @@ const WATCHER_BUS_NAME = 'org.kde.StatusNotifierWatcher';
 const WATCHER_OBJECT_PATH = '/StatusNotifierWatcher';
 const DEFAULT_ITEM_OBJECT_PATH = '/StatusNotifierItem';
 
-const BUS_ADDRESS_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$/;
+const BUS_ADDRESS_REGEX = /^[a-zA-Z_-][a-zA-Z0-9_-]*(\.[a-zA-Z_-][a-zA-Z0-9_-]*)+$/;
 
 let _sniInterfaceInfo = null;
 function getSNIInterfaceInfo() {


### PR DESCRIPTION
## Why

Apps like Cloudflare's `warp-taskbar` register their SNI item using the spec-mandated canonical name `org.kde.StatusNotifierItem-PID-ID`, which contains hyphens. The discriminator regex at `src/extension.js:246` was missing `-` in its character classes, so this name failed the test in `RegisterStatusNotifierItemAsync` and fell through to the `else` branch instead of being resolved to a unique connection name via `GetNameOwner`.

That made the watcher's two registration paths record the same process under two different keys in `this._items`:
- Proactive scan (`_checkForSNI`) → `:1.53/StatusNotifierItem`
- App's own `RegisterStatusNotifierItem` → `org.kde.StatusNotifierItem-3255-1/StatusNotifierItem`

The dedup at `_registerItemInternal:2220` only catches identical keys, so two `trayItem`s were created for one process — visible as a duplicated icon, plus a ghost entry that survived `NameOwnerChanged` cleanup.

## Fix

```diff
-const BUS_ADDRESS_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)+$/;
+const BUS_ADDRESS_REGEX = /^[a-zA-Z_-][a-zA-Z0-9_-]*(\.[a-zA-Z_-][a-zA-Z0-9_-]*)+$/;
```

Aligns the character class with the D-Bus spec (`[A-Z][a-z][0-9]_-`). Both paths now converge on `:1.X`, the dedup catches the second call, one icon. Names without hyphens still match — no regression.

Refs: [D-Bus spec, Valid Names](https://dbus.freedesktop.org/doc/dbus-specification.html) · [SNI spec](https://specifications.freedesktop.org/status-notifier-item/latest-single/)
