### PR TITLE
Set lower limit to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ collapsed app, with each app's full menu available inline as a submenu.
 
 - **Enable overflow icon** - Turn the feature on or off (disabled by default)
 - **Inline icon limit** - Choose how many icons stay directly in the panel
-  (1-20) before the rest overflow
+  (0-20) before the rest overflow. Set it to 0 to keep every tray item in the
+  overflow menu.
 
 The overflow button honours the global Icon Style setting, showing a symbolic
 or a full-colour glyph to match your other tray icons.

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to Status Tray will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+- Inline icon limit can now be set as low as `0`, collapsing every tray item into the overflow menu (Windows-style). Previously the minimum was `1`, which always forced at least one icon to stay inline. Thanks to [@krissedout](https://github.com/krissedout) for the suggestion and patch.
+
 ## [1.9] - 2026-05-13
 
 ### Added

--- a/docs/status-tray.md
+++ b/docs/status-tray.md
@@ -586,7 +586,7 @@ _activateMenuItem(itemId) {
 | `icon-effect-overrides` | `a{ss}` | `{}` | App ID → JSON effect config |
 | `title-aliases` | `a{ss}` | `{}` | Display name → stable app ID (for apps that randomize SNI IDs) |
 | `overflow-enabled` | `b` | `false` | Enable the panel overflow button |
-| `overflow-inline-count` | `i` | `3` | Inline icon limit before items spill into the overflow menu |
+| `overflow-inline-count` | `i` | `3` | Inline icon limit before items spill into the overflow menu; `0` keeps every tray item in overflow |
 
 ### Effect Override Format
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -2803,7 +2803,7 @@ export default class StatusTrayExtension extends Extension {
             return;
 
         const enabled = this._settings.get_boolean('overflow-enabled');
-        const inlineCount = Math.max(1, this._settings.get_int('overflow-inline-count'));
+        const inlineCount = Math.max(0, this._settings.get_int('overflow-inline-count'));
 
         // Passive items aren't visible to the user; exclude them from slot
         // accounting so they don't push real items into the overflow popup,

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1600,7 +1600,7 @@ export default class StatusTrayPreferences extends ExtensionPreferences {
             title: 'Inline icon limit',
             subtitle: 'How many icons stay in the panel before the rest overflow',
             adjustment: new Gtk.Adjustment({
-                lower: 1,
+                lower: 0,
                 upper: 20,
                 step_increment: 1,
                 page_increment: 1,

--- a/src/schemas/org.gnome.shell.extensions.status-tray.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.status-tray.gschema.xml
@@ -59,7 +59,7 @@
     <key name="overflow-inline-count" type="i">
       <default>3</default>
       <summary>Inline icon count</summary>
-      <description>Number of tray items to show directly in the panel before overflowing into the overflow button's menu. Range: 1-20.</description>
+      <description>Number of tray items to show directly in the panel before overflowing into the overflow button's menu. Set to 0 to keep every tray item in the overflow menu. Range: 0-20.</description>
     </key>
 
   </schema>


### PR DESCRIPTION
This just allows people to set the lower limit of overflow to 0 so that all icons go into the overflow menu, like on Windows.