### PR TITLE
Add dynamic preview option for overflow button icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,14 @@ button at the right of the tray. Click it to get a menu that lists each
 collapsed app, with each app's full menu available inline as a submenu.
 
 - **Enable overflow icon** - Turn the feature on or off (disabled by default)
+- **Overflow button icon** - Show a dynamic preview of up to 4 hidden icons or
+  keep the static tray glyph
 - **Inline icon limit** - Choose how many icons stay directly in the panel
   (0-20) before the rest overflow. Set it to 0 to keep every tray item in the
   overflow menu.
 
-The overflow button honours the global Icon Style setting, showing a symbolic
-or a full-colour glyph to match your other tray icons.
+The overflow button honours the global Icon Style setting for both the static
+glyph and dynamic previews.
 
 ### Icon Effects
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to Status Tray will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- Overflow button icons can now use a dynamic preview that shows up to four hidden tray icons. Preferences include a Static option for users who prefer the bundled tray glyph.
+
 ## [1.10] - 2026.05.23
 
 ### Changed

--- a/docs/status-tray.md
+++ b/docs/status-tray.md
@@ -175,7 +175,7 @@ new TrayItem(
 | `_setIcon(iconName)` | Set icon by theme name |
 | `_setIconFromPixmap(pixmapData)` | Set icon from ARGB pixel data |
 | `_replaceIcon(iconNameOrPath)` | Destroy and recreate St.Icon widget (used for overrides) |
-| `_applySymbolicStyle()` | Apply Clutter effects for symbolic mode |
+| `_applySymbolicStyle(targetIcon, iconSize)` | Apply Clutter effects for symbolic mode |
 | `_clearIconExcept(activeSource)` | Clear inactive icon sources (content/gicon/icon_name) |
 | `_loadMenu()` | Fetch menu via DBusMenu and display |
 | `_activateMenuItem(itemId)` | Send click event to menu item |
@@ -299,8 +299,10 @@ and the number of active `TrayItem`s exceeds `overflow-inline-count`.
 
 #### Responsibilities
 
-- Renders one of two bundled glyphs (`icons/status-tray.svg` or
-  `icons/status-tray-symbolic.svg`) depending on the current `icon-mode`.
+- Renders either a dynamic preview of up to four overflowed tray icons or one
+  of two bundled glyphs (`icons/status-tray.svg` or
+  `icons/status-tray-symbolic.svg`) depending on `overflow-icon-style` and
+  the current `icon-mode`.
 - Builds one `PopupMenu.PopupSubMenuMenuItem` per overflowed `TrayItem`,
   labelled with the app's display name and prefixed with a clone of that
   `TrayItem`'s gicon.
@@ -450,7 +452,7 @@ match the panel theme via `-st-icon-style: symbolic`. Tint is still applied
 if configured.
 
 ```javascript
-_applySymbolicStyle() {
+_applySymbolicStyle(targetIcon = this._icon, iconSize = 16) {
     const isSymbolicIcon = iconName?.endsWith('-symbolic');
 
     // Symbolic icons: St.Icon handles recolouring via CSS.
@@ -587,6 +589,7 @@ _activateMenuItem(itemId) {
 | `title-aliases` | `a{ss}` | `{}` | Display name → stable app ID (for apps that randomize SNI IDs) |
 | `overflow-enabled` | `b` | `false` | Enable the panel overflow button |
 | `overflow-inline-count` | `i` | `3` | Inline icon limit before items spill into the overflow menu; `0` keeps every tray item in overflow |
+| `overflow-icon-style` | `s` | `'dynamic'` | `'dynamic'` previews up to four hidden icons; `'static'` uses the bundled tray glyph |
 
 ### Effect Override Format
 
@@ -634,6 +637,7 @@ StatusTrayPreferences (Adw.PreferencesWindow)
     │
     ├── Adw.PreferencesGroup ("Panel Overflow")
     │   ├── Enable overflow icon (Adw.SwitchRow) → overflow-enabled
+    │   ├── Overflow button icon (Adw.ComboRow)  → overflow-icon-style
     │   └── Inline icon limit (Adw.SpinRow)      → overflow-inline-count
     │
     ├── Adw.PreferencesGroup ("Tray Apps")

--- a/src/extension.js
+++ b/src/extension.js
@@ -29,6 +29,10 @@ import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 const DEBUG = false;
 const FALLBACK_ICON_NAME = 'image-loading-symbolic';
 const PIXMAPS_FORMAT = Cogl.PixelFormat.ARGB_8888;
+const OVERFLOW_PREVIEW_LIMIT = 4;
+const OVERFLOW_PREVIEW_SIZE = 18;
+const OVERFLOW_PREVIEW_GRID_ICON_SIZE = 11;
+const OVERFLOW_PREVIEW_STACK_ICON_SIZE = 13;
 
 function debug(msg) {
     if (DEBUG) {
@@ -1180,7 +1184,7 @@ const TrayItem = GObject.registerClass({
         this._applySymbolicStyle();
     }
 
-    _applySymbolicStyle(targetIcon = this._icon) {
+    _applySymbolicStyle(targetIcon = this._icon, iconSize = 16) {
         const iconName = this._icon.icon_name;
         const isSymbolicIcon = iconName && iconName.endsWith('-symbolic');
         // Only force regular style when we loaded a file via gicon — this
@@ -1200,7 +1204,7 @@ const TrayItem = GObject.registerClass({
         const iconMode = this._settings?.get_string('icon-mode') ?? 'symbolic';
         if (iconMode !== 'symbolic') {
             targetIcon.clear_effects();
-            targetIcon.set_style(`icon-size: 16px;${iconStyleCss}`);
+            targetIcon.set_style(`icon-size: ${iconSize}px;${iconStyleCss}`);
             if (isPanelIcon)
                 this.emit('display-changed');
             return;
@@ -1270,7 +1274,7 @@ const TrayItem = GObject.registerClass({
             }
         }
 
-        targetIcon.set_style(`icon-size: 16px;${iconStyleCss}`);
+        targetIcon.set_style(`icon-size: ${iconSize}px;${iconStyleCss}`);
         if (isPanelIcon)
             this.emit('display-changed');
     }
@@ -1796,11 +1800,9 @@ class OverflowButton extends PanelMenu.Button {
 
         this._extensionPath = extensionPath;
         this._settings = settings;
+        this._overflowedItems = [];
+        this._iconActor = null;
 
-        this._icon = new St.Icon({
-            style_class: 'system-status-icon status-tray-icon',
-        });
-        this.add_child(this._icon);
         this.add_style_class_name('status-tray-button');
         this.add_style_class_name('status-tray-overflow-button');
 
@@ -1812,6 +1814,20 @@ class OverflowButton extends PanelMenu.Button {
     }
 
     updateOverflowIcon() {
+        if (this._getOverflowIconStyle() === 'dynamic' && this._overflowedItems.length > 0) {
+            this._setIconActor(this._buildDynamicIcon());
+            return;
+        }
+
+        this._setIconActor(this._buildStaticIcon());
+    }
+
+    _getOverflowIconStyle() {
+        const style = this._settings?.get_string('overflow-icon-style') ?? 'dynamic';
+        return style === 'static' ? 'static' : 'dynamic';
+    }
+
+    _buildStaticIcon() {
         const mode = this._settings?.get_string('icon-mode') ?? 'symbolic';
         const fileName = mode === 'symbolic'
             ? 'status-tray-symbolic.svg'
@@ -1819,10 +1835,73 @@ class OverflowButton extends PanelMenu.Button {
         const file = Gio.File.new_for_path(
             GLib.build_filenamev([this._extensionPath, 'icons', fileName])
         );
-        this._icon.set_gicon(new Gio.FileIcon({ file }));
+        return new St.Icon({
+            style_class: 'system-status-icon status-tray-icon',
+            gicon: new Gio.FileIcon({ file }),
+        });
+    }
+
+    _buildDynamicIcon() {
+        const preview = new St.Widget({
+            style_class: 'system-status-icon status-tray-overflow-preview',
+            x_align: Clutter.ActorAlign.CENTER,
+            y_align: Clutter.ActorAlign.CENTER,
+            width: OVERFLOW_PREVIEW_SIZE,
+            height: OVERFLOW_PREVIEW_SIZE,
+            layout_manager: new Clutter.FixedLayout(),
+        });
+        preview.set_size(OVERFLOW_PREVIEW_SIZE, OVERFLOW_PREVIEW_SIZE);
+
+        const items = this._overflowedItems.slice(0, OVERFLOW_PREVIEW_LIMIT);
+        const positions = this._getPreviewPositions(items.length);
+
+        for (let i = 0; i < items.length; i++) {
+            const { x, y, size } = positions[i];
+            const icon = new St.Icon({
+                style_class: 'status-tray-overflow-preview-icon',
+            });
+            icon.set_position(x, y);
+            icon.set_size(size, size);
+            this._applyTrayItemIcon(icon, items[i], size);
+            preview.add_child(icon);
+        }
+
+        return preview;
+    }
+
+    _getPreviewPositions(count) {
+        if (count === 1)
+            return [{ x: 1, y: 1, size: 16 }];
+        if (count === 2)
+            return [
+                { x: 0, y: 2, size: OVERFLOW_PREVIEW_STACK_ICON_SIZE },
+                { x: 6, y: 2, size: OVERFLOW_PREVIEW_STACK_ICON_SIZE },
+            ];
+        if (count === 3)
+            return [
+                { x: 0, y: 0, size: OVERFLOW_PREVIEW_GRID_ICON_SIZE },
+                { x: 7, y: 0, size: OVERFLOW_PREVIEW_GRID_ICON_SIZE },
+                { x: 4, y: 7, size: OVERFLOW_PREVIEW_GRID_ICON_SIZE },
+            ];
+        return [
+            { x: 0, y: 0, size: OVERFLOW_PREVIEW_GRID_ICON_SIZE },
+            { x: 7, y: 0, size: OVERFLOW_PREVIEW_GRID_ICON_SIZE },
+            { x: 0, y: 7, size: OVERFLOW_PREVIEW_GRID_ICON_SIZE },
+            { x: 7, y: 7, size: OVERFLOW_PREVIEW_GRID_ICON_SIZE },
+        ];
+    }
+
+    _setIconActor(actor) {
+        if (this._iconActor)
+            this._iconActor.destroy();
+
+        this._iconActor = actor;
+        this.add_child(actor);
     }
 
     setOverflowedItems(trayItems) {
+        this._overflowedItems = trayItems;
+
         // Disconnect from any TrayItems no longer in the overflow set before
         // rebuilding; connectObject/disconnectObject uses `this` as the owner.
         for (const trayItem of this._rows.keys()) {
@@ -1859,6 +1938,8 @@ class OverflowButton extends PanelMenu.Button {
                 this._refreshRow(trayItem);
             }, this);
         }
+
+        this.updateOverflowIcon();
     }
 
     _seedPlaceholder(menu) {
@@ -1870,24 +1951,28 @@ class OverflowButton extends PanelMenu.Button {
     }
 
     _applyRowIcon(subItem, trayItem) {
+        this._applyTrayItemIcon(subItem.icon, trayItem);
+    }
+
+    _applyTrayItemIcon(targetIcon, trayItem, iconSize = 16) {
         const src = trayItem._icon;
         if (!src)
-            return;
+            return false;
 
         // Reset every potential source so switching between branches (e.g.
         // pixmap → named icon on refresh) doesn't leave stale state behind.
-        subItem.icon.gicon = null;
-        subItem.icon.icon_name = null;
-        subItem.icon.content = null;
-        subItem.icon.set_size(-1, -1);
+        targetIcon.gicon = null;
+        targetIcon.icon_name = null;
+        targetIcon.content = null;
+        targetIcon.set_size(-1, -1);
 
         let sourceApplied = false;
         const gicon = src.get_gicon?.();
         if (gicon) {
-            subItem.icon.set_gicon(gicon);
+            targetIcon.set_gicon(gicon);
             sourceApplied = true;
         } else if (src.icon_name) {
-            subItem.icon.set_icon_name(src.icon_name);
+            targetIcon.set_icon_name(src.icon_name);
             sourceApplied = true;
         } else if (src.content) {
             // Pixmap-backed icons (Electron/Flatpak apps, IconPixmap fallback)
@@ -1897,26 +1982,28 @@ class OverflowButton extends PanelMenu.Button {
             // Clutter.Content has no intrinsic size when assigned via the
             // content property.
             const scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
-            const size = 16 * scaleFactor;
-            subItem.icon.set({
+            const scaledSize = iconSize * scaleFactor;
+            targetIcon.set({
                 content: src.content,
-                width: size,
-                height: size,
+                width: scaledSize,
+                height: scaledSize,
                 content_gravity: Clutter.ContentGravity.RESIZE_ASPECT,
             });
             sourceApplied = true;
         }
 
         if (!sourceApplied) {
-            subItem.icon.set_icon_name(FALLBACK_ICON_NAME);
-            return;
+            targetIcon.set_icon_name(FALLBACK_ICON_NAME);
+            targetIcon.set_style(`icon-size: ${iconSize}px;`);
+            return false;
         }
 
         // Mirror the panel icon's symbolic/recolour/effect treatment onto the
         // row so the overflow popup matches the per-app tuning. Delegates to
         // the same routine the panel uses; the trayItem reads its own _icon's
         // properties to decide style/effects.
-        trayItem._applySymbolicStyle?.(subItem.icon);
+        trayItem._applySymbolicStyle?.(targetIcon, iconSize);
+        return true;
     }
 
     _refreshRow(trayItem) {
@@ -1926,6 +2013,7 @@ class OverflowButton extends PanelMenu.Button {
         const label = trayItem._computeDisplayName?.() || trayItem._appId || 'Unknown';
         subItem.label.text = label;
         this._applyRowIcon(subItem, trayItem);
+        this.updateOverflowIcon();
         // Force the submenu to refetch on next open so menu contents stay
         // in sync if the app's menu tree changed. Re-seed the placeholder
         // so the submenu is still openable (see note in setOverflowedItems).
@@ -1937,6 +2025,8 @@ class OverflowButton extends PanelMenu.Button {
         for (const trayItem of this._rows.keys())
             trayItem.disconnectObject(this);
         this._rows.clear();
+        this._overflowedItems = [];
+        this._iconActor = null;
         super.destroy();
     }
 });
@@ -2485,6 +2575,10 @@ export default class StatusTrayExtension extends Extension {
             },
             'changed::overflow-inline-count', () => {
                 debug('overflow-inline-count setting changed');
+                this._applyOverflow();
+            },
+            'changed::overflow-icon-style', () => {
+                debug('overflow-icon-style setting changed');
                 this._applyOverflow();
             },
             this

--- a/src/extension.js
+++ b/src/extension.js
@@ -31,6 +31,7 @@ const FALLBACK_ICON_NAME = 'image-loading-symbolic';
 const PIXMAPS_FORMAT = Cogl.PixelFormat.ARGB_8888;
 const OVERFLOW_PREVIEW_LIMIT = 4;
 const OVERFLOW_PREVIEW_SIZE = 18;
+const OVERFLOW_PREVIEW_SOLO_ICON_SIZE = 16;
 const OVERFLOW_PREVIEW_GRID_ICON_SIZE = 11;
 const OVERFLOW_PREVIEW_STACK_ICON_SIZE = 13;
 
@@ -1802,6 +1803,7 @@ class OverflowButton extends PanelMenu.Button {
         this._settings = settings;
         this._overflowedItems = [];
         this._iconActor = null;
+        this._iconUpdateSourceId = 0;
 
         this.add_style_class_name('status-tray-button');
         this.add_style_class_name('status-tray-overflow-button');
@@ -1814,12 +1816,33 @@ class OverflowButton extends PanelMenu.Button {
     }
 
     updateOverflowIcon() {
+        if (this._iconUpdateSourceId) {
+            GLib.source_remove(this._iconUpdateSourceId);
+            this._iconUpdateSourceId = 0;
+        }
+
         if (this._getOverflowIconStyle() === 'dynamic' && this._overflowedItems.length > 0) {
             this._setIconActor(this._buildDynamicIcon());
             return;
         }
 
         this._setIconActor(this._buildStaticIcon());
+    }
+
+    // Idle-coalesce repeated rebuilds. A single setting change (e.g.
+    // icon-mode) can fire 'display-changed' on every overflowed TrayItem in
+    // quick succession; without coalescing each one would destroy and
+    // recreate the preview widget. The idle callback runs once after the
+    // current event burst settles.
+    _scheduleIconUpdate() {
+        if (this._iconUpdateSourceId)
+            return;
+
+        this._iconUpdateSourceId = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+            this._iconUpdateSourceId = 0;
+            this.updateOverflowIcon();
+            return GLib.SOURCE_REMOVE;
+        });
     }
 
     _getOverflowIconStyle() {
@@ -1871,11 +1894,11 @@ class OverflowButton extends PanelMenu.Button {
 
     _getPreviewPositions(count) {
         if (count === 1)
-            return [{ x: 1, y: 1, size: 16 }];
+            return [{ x: 1, y: 1, size: OVERFLOW_PREVIEW_SOLO_ICON_SIZE }];
         if (count === 2)
             return [
                 { x: 0, y: 2, size: OVERFLOW_PREVIEW_STACK_ICON_SIZE },
-                { x: 6, y: 2, size: OVERFLOW_PREVIEW_STACK_ICON_SIZE },
+                { x: 5, y: 2, size: OVERFLOW_PREVIEW_STACK_ICON_SIZE },
             ];
         if (count === 3)
             return [
@@ -1957,7 +1980,7 @@ class OverflowButton extends PanelMenu.Button {
     _applyTrayItemIcon(targetIcon, trayItem, iconSize = 16) {
         const src = trayItem._icon;
         if (!src)
-            return false;
+            return;
 
         // Reset every potential source so switching between branches (e.g.
         // pixmap → named icon on refresh) doesn't leave stale state behind.
@@ -1995,7 +2018,7 @@ class OverflowButton extends PanelMenu.Button {
         if (!sourceApplied) {
             targetIcon.set_icon_name(FALLBACK_ICON_NAME);
             targetIcon.set_style(`icon-size: ${iconSize}px;`);
-            return false;
+            return;
         }
 
         // Mirror the panel icon's symbolic/recolour/effect treatment onto the
@@ -2003,7 +2026,6 @@ class OverflowButton extends PanelMenu.Button {
         // the same routine the panel uses; the trayItem reads its own _icon's
         // properties to decide style/effects.
         trayItem._applySymbolicStyle?.(targetIcon, iconSize);
-        return true;
     }
 
     _refreshRow(trayItem) {
@@ -2013,7 +2035,7 @@ class OverflowButton extends PanelMenu.Button {
         const label = trayItem._computeDisplayName?.() || trayItem._appId || 'Unknown';
         subItem.label.text = label;
         this._applyRowIcon(subItem, trayItem);
-        this.updateOverflowIcon();
+        this._scheduleIconUpdate();
         // Force the submenu to refetch on next open so menu contents stay
         // in sync if the app's menu tree changed. Re-seed the placeholder
         // so the submenu is still openable (see note in setOverflowedItems).
@@ -2022,6 +2044,10 @@ class OverflowButton extends PanelMenu.Button {
     }
 
     destroy() {
+        if (this._iconUpdateSourceId) {
+            GLib.source_remove(this._iconUpdateSourceId);
+            this._iconUpdateSourceId = 0;
+        }
         for (const trayItem of this._rows.keys())
             trayItem.disconnectObject(this);
         this._rows.clear();

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1596,6 +1596,25 @@ export default class StatusTrayPreferences extends ExtensionPreferences {
         });
         overflowGroup.add(overflowEnabledRow);
 
+        const overflowIconRow = new Adw.ComboRow({
+            title: 'Overflow button icon',
+            subtitle: 'Preview hidden icons or use the standard tray icon',
+            sensitive: overflowEnabledRow.get_active(),
+        });
+        const overflowIconModel = new Gtk.StringList();
+        overflowIconModel.append('Dynamic preview');
+        overflowIconModel.append('Static icon');
+        overflowIconRow.set_model(overflowIconModel);
+
+        const currentOverflowIconStyle = this._settings.get_string('overflow-icon-style');
+        overflowIconRow.set_selected(currentOverflowIconStyle === 'static' ? 1 : 0);
+
+        overflowIconRow.connect('notify::selected', () => {
+            const selected = overflowIconRow.get_selected();
+            this._settings.set_string('overflow-icon-style', selected === 1 ? 'static' : 'dynamic');
+        });
+        overflowGroup.add(overflowIconRow);
+
         const overflowCountRow = new Adw.SpinRow({
             title: 'Inline icon limit',
             subtitle: 'How many icons stay in the panel before the rest overflow',
@@ -1613,6 +1632,7 @@ export default class StatusTrayPreferences extends ExtensionPreferences {
         });
         overflowEnabledRow.connect('notify::active', () => {
             overflowCountRow.set_sensitive(overflowEnabledRow.get_active());
+            overflowIconRow.set_sensitive(overflowEnabledRow.get_active());
         });
         overflowGroup.add(overflowCountRow);
 

--- a/src/schemas/org.gnome.shell.extensions.status-tray.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.status-tray.gschema.xml
@@ -62,5 +62,11 @@
       <description>Number of tray items to show directly in the panel before overflowing into the overflow button's menu. Set to 0 to keep every tray item in the overflow menu. Range: 0-20.</description>
     </key>
 
+    <key name="overflow-icon-style" type="s">
+      <default>'dynamic'</default>
+      <summary>Overflow icon style</summary>
+      <description>How to render the overflow button in the panel. 'dynamic' previews up to four hidden tray icons; 'static' uses the bundled tray glyph.</description>
+    </key>
+
   </schema>
 </schemalist>

--- a/src/schemas/org.gnome.shell.extensions.status-tray.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.status-tray.gschema.xml
@@ -63,6 +63,10 @@
     </key>
 
     <key name="overflow-icon-style" type="s">
+      <choices>
+        <choice value="dynamic"/>
+        <choice value="static"/>
+      </choices>
       <default>'dynamic'</default>
       <summary>Overflow icon style</summary>
       <description>How to render the overflow button in the panel. 'dynamic' previews up to four hidden tray icons; 'static' uses the bundled tray glyph.</description>

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -19,3 +19,12 @@
     icon-size: 16px;
     -st-icon-style: symbolic;
 }
+
+.status-tray-overflow-preview {
+    width: 18px;
+    height: 18px;
+}
+
+.status-tray-overflow-preview-icon {
+    icon-size: 11px;
+}


### PR DESCRIPTION
Replaces the bundled overflow glyph with an optional live preview composed from up to four of the currently-hidden tray icons.

### What's new

- **Dynamic preview (default)** — When the overflow button is rendered, it shows a 1/2/3/4-icon preview of the first hidden tray items, mirroring the same icon source pipeline the panel uses (gicon → `icon_name` → pixmap `Clutter.Content`). Layout adapts to the count: one icon centered, two stacked horizontally, three in a 2+1 grid, four in a 2×2 grid.
- **Static glyph** — Original bundled `status-tray.svg` / `status-tray-symbolic.svg`, for users who prefer it.
- **New preference:** `Overflow button icon` (`dynamic` / `static`), defaulting to `dynamic`. Disabled state follows the existing *Enable overflow icon* toggle.

### Implementation notes

- Adds `overflow-icon-style` (string, default `'dynamic'`) to the GSettings schema.
- Overflow button now keeps an `_iconActor` and swaps between a dynamic `St.Widget` and a static `St.Icon`, destroying the previous actor on change to avoid leaking `Clutter.Content` references.
- `_applySymbolicStyle` and `_applyRowIcon` were refactored to share a new `_applyTrayItemIcon(targetIcon, trayItem, iconSize)` helper so panel rows, menu rows, and the new preview all go through the same gicon/`icon_name`/pixmap mirroring path. The dynamic preview therefore inherits the global `icon-mode` (symbolic vs. full-colour) automatically.
- New CSS classes: `.status-tray-overflow-preview` (18×18 frame) and `.status-tray-overflow-preview-icon` (default icon size 11px, overridden inline to 13px for the 2-icon stack and 16px for the 1-icon layout).
- Updates `README.md`, `docs/status-tray.md`, and `changelog.md` (under `[Unreleased]`).

### Screenshots

<img width="256" height="47" alt="image" src="https://github.com/user-attachments/assets/e48cec60-bd52-4fc7-a1ce-34aa4706beb7" />
<img width="261" height="164" alt="image" src="https://github.com/user-attachments/assets/32f3755c-2585-4b2f-af2b-4d7eea433d75" />
